### PR TITLE
More on the VIC parser

### DIFF
--- a/CPT331.Data.Parsers/VicKmlParser.cs
+++ b/CPT331.Data.Parsers/VicKmlParser.cs
@@ -22,9 +22,31 @@ namespace CPT331.Data.Parsers
 
 		internal const string VIC = "VIC";
 
+		private static Dictionary<string, string> CreateMappingDictionary(string fileName)
+		{
+			Dictionary<string, string> mappingDictionary = new Dictionary<string, string>();
+
+			string mappingFileName = fileName.Replace($"{VIC}.kml", $"{VIC}-Mapping.xml");
+			if (File.Exists(mappingFileName) == true)
+			{
+				XmlDocument xmlDocument = new XmlDocument();
+				xmlDocument.Load(mappingFileName);
+
+				XmlNodeList xmlNodeList = xmlDocument.SelectNodes("/Workbook/Worksheet/Table/Row[position() > 1]");
+				foreach (XmlNode xmlNode in xmlNodeList)
+				{
+					mappingDictionary.Add(xmlNode.ChildNodes[0].InnerText.Trim(), xmlNode.ChildNodes[1].InnerText.Trim());
+				}
+			}
+
+			return mappingDictionary;
+		}
+
 		protected override void OnParse(string fileName, List<Coordinate> coordinates)
 		{
 			OutputStreams.WriteLine($"Parsing {VIC} data...");
+
+			Dictionary<string, string> mappingDictionary = CreateMappingDictionary(fileName);
 
 			XmlDocument xmlDocument = new XmlDocument();
 			xmlDocument.Load(fileName);
@@ -33,28 +55,37 @@ namespace CPT331.Data.Parsers
 			foreach (XmlNode xmlNode in xmlNodeList)
 			{
 				string name = xmlNode.SelectSingleNode("name").InnerText;
-				Console.WriteLine(name);
-				//	OutputStreams.WriteLine($"Processing {name}...");
-				//	
-				//	XmlNodeList coordinateXmlNodes = xmlNode.SelectNodes("Polygon/outerBoundaryIs/LinearRing/coordinates | MultiGeometry/Polygon/outerBoundaryIs/LinearRing/coordinates");
-				//	string coordinateValues = "";
-				//	
-				//	foreach (XmlNode coordinateXmlNode in coordinateXmlNodes)
-				//	{
-				//		coordinateValues = $"{coordinateValues} {coordinateXmlNode.InnerText}";
-				//	}
-				//	
-				//	coordinates.Clear();
-				//	
-				//	string[] coordinateLines = coordinateValues.Split(" ".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
-				//	foreach (string coordinateLine in coordinateLines)
-				//	{
-				//		string[] coordinateParts = coordinateLine.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-				//	
-				//		coordinates.Add(new Coordinate(Double.Parse(coordinateParts[1]), Double.Parse(coordinateParts[0])));
-				//	}
-				//	
-				//	base.Commit(coordinates, name);
+
+				if (mappingDictionary.ContainsKey(name) == true)
+				{
+					string newName = mappingDictionary[name];
+
+					OutputStreams.WriteLine($"Translating {name} to {newName}...");
+
+					name = newName;
+				}
+
+				OutputStreams.WriteLine($"Processing {name}...");
+				
+				XmlNodeList coordinateXmlNodes = xmlNode.SelectNodes("Polygon/outerBoundaryIs/LinearRing/coordinates | MultiGeometry/Polygon/outerBoundaryIs/LinearRing/coordinates");
+				string coordinateValues = "";
+				
+				foreach (XmlNode coordinateXmlNode in coordinateXmlNodes)
+				{
+					coordinateValues = $"{coordinateValues} {coordinateXmlNode.InnerText}";
+				}
+				
+				coordinates.Clear();
+				
+				string[] coordinateLines = coordinateValues.Split(" ".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+				foreach (string coordinateLine in coordinateLines)
+				{
+					string[] coordinateParts = coordinateLine.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+				
+					coordinates.Add(new Coordinate(Double.Parse(coordinateParts[1]), Double.Parse(coordinateParts[0])));
+				}
+				
+				base.Commit(coordinates, name);
 			}
 
 			base.OnParse(fileName, coordinates);

--- a/CPT331.WebAPI.Tests/Controllers/CrimeControllerTest.cs
+++ b/CPT331.WebAPI.Tests/Controllers/CrimeControllerTest.cs
@@ -20,7 +20,7 @@ namespace CPT331.WebAPI.Tests.Controllers
         {
             CrimeController controller = new CrimeController();
 
-			CrimeByCoordinateModel crimeByCoordinateModel = controller.CrimesByCoordinate(151.1743105, -33.9112549);
+			CrimeByCoordinateModel crimeByCoordinateModel = controller.CrimesByCoordinate(-33.9112549, 151.1743105);
    
             Assert.IsNotNull(crimeByCoordinateModel);
         }


### PR DESCRIPTION
@6nop @s3364942 @s3494110 @s3482247 

In this PR:
 - The VIC KML parser
 - Note that data for VIC LGAs is incomplete. Geography for the following LGAs is missing:

1. Alpine
2. Buloke
3. East Gippsland
4. Gannawarra
5. Glenelg
6. Hindmarsh
7. Horsham
8. Indigo
9. Mildura
10. Moira
11. Moyne
12. Southern Grampians
13. Swan Hill
14. Towong
15. Warrnambool
16. West Wimmera
17. Wodonga
18. Yarriambiack

![missing](https://cloud.githubusercontent.com/assets/22001846/19428119/d92aff64-9493-11e6-92f4-25b5d8960043.gif)
