### PR TITLE
Remove TAS winding reversal

### DIFF
--- a/CPT331.Data.Parsers/TasKmlParser.cs
+++ b/CPT331.Data.Parsers/TasKmlParser.cs
@@ -59,8 +59,6 @@ namespace CPT331.Data.Parsers
 					}
 				}
 
-				coordinates.Reverse();
-
 				base.Commit(coordinates, name);
 			}
 


### PR DESCRIPTION
@6nop @s3364942 @s3494110 @s3482247 

In this PR:
 - One-liner! Reversal of winding order was not required for this file

![just-as-expected](https://cloud.githubusercontent.com/assets/22001846/19546074/19cf138e-96d8-11e6-9b54-35989c088f0f.gif)
